### PR TITLE
Handle discovery timeout gracefully

### DIFF
--- a/local_ntp/common/__init__.py
+++ b/local_ntp/common/__init__.py
@@ -20,12 +20,19 @@ def save_settings(path, data):
 
 
 def discover_server(port, timeout=2):
-    """Broadcasts a discovery packet and returns server IP if found."""
+    """Broadcasts a discovery packet and returns server IP if found.
+
+    If no response is received before the ``timeout`` expires, ``None`` is
+    returned instead of raising :class:`socket.timeout`.
+    """
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         s.settimeout(timeout)
         s.sendto(b"CUSTONTP_DISCOVER", ("<broadcast>", port))
-        data, addr = s.recvfrom(1024)
+        try:
+            data, addr = s.recvfrom(1024)
+        except socket.timeout:
+            return None
         if data == b"CUSTONTP_RESPONSE":
             return addr[0]
     return None


### PR DESCRIPTION
## Summary
- prevent `socket.timeout` from propagating in `discover_server`
- document that `discover_server` returns `None` when no response is received

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689566d7adcc8322959e01f3adaf9127