### PR TITLE
Refactor time synchronization logic into shared module

### DIFF
--- a/Sources/client_gui.py
+++ b/Sources/client_gui.py
@@ -1,8 +1,6 @@
 import ctypes
 import tkinter as tk
 from tkinter import messagebox, scrolledtext
-import subprocess
-import time
 import threading
 import sys
 import os
@@ -13,6 +11,7 @@ from local_ntp.common import (
     discover_server,
     get_time_from_server,
 )
+from local_ntp.sync import sync_time
 
 class ClientGUI:
     CONFIG_FILE = "client_settings.json"
@@ -72,70 +71,7 @@ class ClientGUI:
             server_time, rtt = get_time_from_server(server_ip, port)
             self.log(f"[CLIENT] Измеренный ping (RTT): {rtt*1000:.2f} мс")
             self.log(f"[CLIENT] Получено время: {server_time}")
-                # Логика разбора времени с миллисекундами
-                if '.' in server_time:
-                    date_str, time_str = server_time.split(' ')
-                    time_main, ms = time_str.split('.')
-                    self.log(f"[CLIENT] Получено время с миллисекундами: {date_str} {time_main}.{ms}")
-                else:
-                    date_str, time_str = server_time.split(' ')
-                    ms = '000'
-                # Корректируем время на половину RTT (только для логов)
-                from datetime import datetime, timedelta
-                dt_format = '%Y-%m-%d %H:%M:%S.%f'
-                if '.' in server_time:
-                    dt = datetime.strptime(server_time, dt_format)
-                else:
-                    dt = datetime.strptime(server_time, '%Y-%m-%d %H:%M:%S')
-                corrected_dt = dt + timedelta(seconds=rtt/2)
-                self.log(f"[CLIENT] Время с учётом ping/2: {corrected_dt.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}")
-                # Ждём половину RTT перед установкой времени
-                self.log(f"[CLIENT] Ожидание {rtt/2:.4f} сек для учёта ping/2 перед установкой времени...")
-                time.sleep(rtt/2)
-                # Преобразуем дату из ГГГГ-ММ-ДД в ДД-ММ-ГГ
-                y, m, d = date_str.split('-')
-                date_for_win = f"{d}-{m}-{y[2:]}"
-                try:
-                    # Попытка установить время через WinAPI с миллисекундами (теперь сервер всегда шлёт UTC)
-                    import ctypes
-                    # НЕ переводим в UTC, сервер уже шлёт UTC
-                    if '.' in server_time:
-                        dt_utc = datetime.strptime(f"{date_str} {time_str}", dt_format)
-                    else:
-                        dt_utc = datetime.strptime(f"{date_str} {time_str}", '%Y-%m-%d %H:%M:%S')
-                    class SYSTEMTIME(ctypes.Structure):
-                        _fields_ = [
-                            ("wYear", ctypes.c_ushort),
-                            ("wMonth", ctypes.c_ushort),
-                            ("wDayOfWeek", ctypes.c_ushort),
-                            ("wDay", ctypes.c_ushort),
-                            ("wHour", ctypes.c_ushort),
-                            ("wMinute", ctypes.c_ushort),
-                            ("wSecond", ctypes.c_ushort),
-                            ("wMilliseconds", ctypes.c_ushort),
-                        ]
-                    st = SYSTEMTIME()
-                    st.wYear = dt_utc.year
-                    st.wMonth = dt_utc.month
-                    st.wDay = dt_utc.day
-                    st.wHour = dt_utc.hour
-                    st.wMinute = dt_utc.minute
-                    st.wSecond = dt_utc.second
-                    st.wMilliseconds = int(dt_utc.microsecond / 1000)
-                    res = ctypes.windll.kernel32.SetSystemTime(ctypes.byref(st))
-                    if res:
-                        self.log(f"[CLIENT] Время установлено через WinAPI (UTC): {dt_utc.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}")
-                    else:
-                        self.log(f"[CLIENT] Не удалось установить время через WinAPI. Код ошибки: {ctypes.GetLastError()}")
-                except Exception as e:
-                    self.log(f"[CLIENT] Ошибка при установке времени через WinAPI: {e}")
-                # Также пробуем стандартный способ для совместимости
-                try:
-                    subprocess.run(f'date {date_for_win}', shell=True, check=True)
-                    subprocess.run(f'time {time_str[:8]}', shell=True, check=True)  # только до секунд
-                    self.log(f"[CLIENT] Время синхронизировано!")
-                except Exception as e:
-                    self.log(f"[CLIENT] Не удалось изменить время. Запустите программу от имени администратора! Ошибка: {e}")
+            sync_time(server_time, rtt, self.log)
         except Exception as e:
             self.log(f"[CLIENT] Ошибка: {e}")
 

--- a/Sources/client_pyqt.py
+++ b/Sources/client_pyqt.py
@@ -1,9 +1,7 @@
 import sys
 import threading
 import os
-import subprocess
 import ctypes
-import time
 
 from local_ntp.common import (
     load_settings,
@@ -11,6 +9,7 @@ from local_ntp.common import (
     discover_server,
     get_time_from_server,
 )
+from local_ntp.sync import sync_time
 
 from PyQt5 import QtWidgets, QtCore
 
@@ -75,55 +74,7 @@ class ClientGUI(QtWidgets.QWidget):
             server_time, rtt = get_time_from_server(server_ip, port)
             self.log(f'[CLIENT] Измеренный ping (RTT): {rtt*1000:.2f} мс')
             self.log(f'[CLIENT] Получено время: {server_time}')
-                date_str, time_str = server_time.split(' ')
-                from datetime import datetime, timedelta
-                dt_format = '%Y-%m-%d %H:%M:%S.%f'
-                if '.' not in time_str:
-                    dt = datetime.strptime(server_time, '%Y-%m-%d %H:%M:%S')
-                else:
-                    dt = datetime.strptime(server_time, dt_format)
-                corrected_dt = dt + timedelta(seconds=rtt/2)
-                self.log(f'[CLIENT] Время с учётом ping/2: {corrected_dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]}')
-                time.sleep(rtt/2)
-                y, m, d = date_str.split('-')
-                date_for_win = f'{d}-{m}-{y[2:]}'
-                try:
-                    if '.' in server_time:
-                        dt_utc = datetime.strptime(server_time, dt_format)
-                    else:
-                        dt_utc = datetime.strptime(server_time, '%Y-%m-%d %H:%M:%S')
-                    class SYSTEMTIME(ctypes.Structure):
-                        _fields_ = [
-                            ('wYear', ctypes.c_ushort),
-                            ('wMonth', ctypes.c_ushort),
-                            ('wDayOfWeek', ctypes.c_ushort),
-                            ('wDay', ctypes.c_ushort),
-                            ('wHour', ctypes.c_ushort),
-                            ('wMinute', ctypes.c_ushort),
-                            ('wSecond', ctypes.c_ushort),
-                            ('wMilliseconds', ctypes.c_ushort),
-                        ]
-                    st = SYSTEMTIME()
-                    st.wYear = dt_utc.year
-                    st.wMonth = dt_utc.month
-                    st.wDay = dt_utc.day
-                    st.wHour = dt_utc.hour
-                    st.wMinute = dt_utc.minute
-                    st.wSecond = dt_utc.second
-                    st.wMilliseconds = int(dt_utc.microsecond/1000)
-                    res = ctypes.windll.kernel32.SetSystemTime(ctypes.byref(st))
-                    if res:
-                        self.log('[CLIENT] Время установлено через WinAPI')
-                    else:
-                        self.log(f'[CLIENT] Не удалось установить время через WinAPI. Код ошибки: {ctypes.GetLastError()}')
-                except Exception as e:
-                    self.log(f'[CLIENT] Ошибка при установке времени через WinAPI: {e}')
-                try:
-                    subprocess.run(f'date {date_for_win}', shell=True, check=True)
-                    subprocess.run(f'time {time_str[:8]}', shell=True, check=True)
-                    self.log('[CLIENT] Время синхронизировано!')
-                except Exception as e:
-                    self.log(f'[CLIENT] Не удалось изменить время. Запустите программу от имени администратора! Ошибка: {e}')
+            sync_time(server_time, rtt, self.log)
         except Exception as e:
             self.log(f'[CLIENT] Ошибка: {e}')
 

--- a/local_ntp/sync.py
+++ b/local_ntp/sync.py
@@ -1,0 +1,93 @@
+"""Utilities for synchronizing local time with a server."""
+
+import subprocess
+import ctypes
+import time
+from datetime import datetime, timedelta
+
+
+def sync_time(server_time: str, rtt: float, log_callback):
+    """Parse, adjust and set system time based on server response.
+
+    Args:
+        server_time: Time string received from the server in the format
+            ``YYYY-MM-DD HH:MM:SS`` with optional milliseconds.
+        rtt: Round trip time in seconds.
+        log_callback: Callable used for logging messages.
+    """
+
+    if "." in server_time:
+        date_str, time_str = server_time.split(" ")
+        time_main, ms = time_str.split(".")
+        log_callback(
+            f"[CLIENT] Получено время с миллисекундами: {date_str} {time_main}.{ms}"
+        )
+    else:
+        date_str, time_str = server_time.split(" ")
+        ms = "000"
+
+    dt_format = "%Y-%m-%d %H:%M:%S.%f"
+    if "." in server_time:
+        dt = datetime.strptime(server_time, dt_format)
+    else:
+        dt = datetime.strptime(server_time, "%Y-%m-%d %H:%M:%S")
+
+    corrected_dt = dt + timedelta(seconds=rtt / 2)
+    log_callback(
+        f"[CLIENT] Время с учётом ping/2: {corrected_dt.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}"
+    )
+    log_callback(
+        f"[CLIENT] Ожидание {rtt/2:.4f} сек для учёта ping/2 перед установкой времени..."
+    )
+    time.sleep(rtt / 2)
+
+    y, m, d = date_str.split("-")
+    date_for_win = f"{d}-{m}-{y[2:]}"
+
+    try:
+        if "." in server_time:
+            dt_utc = datetime.strptime(f"{date_str} {time_str}", dt_format)
+        else:
+            dt_utc = datetime.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M:%S")
+
+        class SYSTEMTIME(ctypes.Structure):
+            _fields_ = [
+                ("wYear", ctypes.c_ushort),
+                ("wMonth", ctypes.c_ushort),
+                ("wDayOfWeek", ctypes.c_ushort),
+                ("wDay", ctypes.c_ushort),
+                ("wHour", ctypes.c_ushort),
+                ("wMinute", ctypes.c_ushort),
+                ("wSecond", ctypes.c_ushort),
+                ("wMilliseconds", ctypes.c_ushort),
+            ]
+
+        st = SYSTEMTIME()
+        st.wYear = dt_utc.year
+        st.wMonth = dt_utc.month
+        st.wDay = dt_utc.day
+        st.wHour = dt_utc.hour
+        st.wMinute = dt_utc.minute
+        st.wSecond = dt_utc.second
+        st.wMilliseconds = int(dt_utc.microsecond / 1000)
+        res = ctypes.windll.kernel32.SetSystemTime(ctypes.byref(st))
+        if res:
+            log_callback(
+                f"[CLIENT] Время установлено через WinAPI (UTC): {dt_utc.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}"
+            )
+        else:
+            log_callback(
+                f"[CLIENT] Не удалось установить время через WinAPI. Код ошибки: {ctypes.GetLastError()}"
+            )
+    except Exception as e:
+        log_callback(f"[CLIENT] Ошибка при установке времени через WinAPI: {e}")
+
+    try:
+        subprocess.run(f"date {date_for_win}", shell=True, check=True)
+        subprocess.run(f"time {time_str[:8]}", shell=True, check=True)
+        log_callback("[CLIENT] Время синхронизировано!")
+    except Exception as e:
+        log_callback(
+            "[CLIENT] Не удалось изменить время. Запустите программу от имени администратора! Ошибка: {e}"
+        )
+


### PR DESCRIPTION
## Summary
- add `sync_time` helper in `local_ntp.sync` for parsing, correcting and setting system time
- reuse `sync_time` in Tkinter and PyQt clients to centralize sync logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689566cff88c832290762e1e2b067c0e